### PR TITLE
Audit subscribe annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.1.2  - 2016.02.11
+
+* [FEATURE] Add `has_subscribe_annotations?`
+
 ## 0.1.1  - Unreleased
 
 * [ENHANCEMENT] Brand name case-insensitive in `has_brand_anchoring?`

--- a/README.md
+++ b/README.md
@@ -19,4 +19,6 @@ Yt::Audit.has_info_cards?('rF711XAtrVg')
 # => true
 Yt::Audit.has_brand_anchoring?('rF711XAtrVg', 'Budweiser')
 # => true
+Yt::Audit.has_subscribe_annotations?('rF711XAtrVg')
+# => false
 ```

--- a/lib/yt/audit.rb
+++ b/lib/yt/audit.rb
@@ -5,7 +5,7 @@ module Yt
   module Audit
     # Audit any info card of a video
     # @param [String] video_id the video to audit.
-    # @return true if the video has any info card.
+    # @return [Boolean] if the video has any info card.
     # @raise [NoMethodError] if video_id is not a valid video.
     def self.has_info_cards?(video_id)
       Yt::Annotations.for(video_id).any? do |annotation|
@@ -16,11 +16,21 @@ module Yt
     # Audit brand anchoring of a video
     # @param [String] video_id the video to audit.
     # @param [String] brand name of the video to audit.
-    # @return true if the video title includes brand name.
+    # @return [Boolean] if the video title includes brand name.
     # @raise [Yt::Errors::NoItems] if video_id is not a valid video.
     def self.has_brand_anchoring?(video_id, brand)
       video_title = Yt::Video.new(id: video_id).title
-      video_title.upcase.include? brand.upcase
+      !!video_title[/#{brand}/i]
+    end
+
+    # Audit any subscribe annotation of a video
+    # @param [String] video_id the video to audit.
+    # @return [Boolean] if the video has any link to subscribe in the annotations.
+    # @raise [NoMethodError] if video_id is not a valid video.
+    def self.has_subscribe_annotations?(video_id)
+      Yt::Annotations.for(video_id).any? do |annotation|
+        annotation.link && annotation.link[:type] == :subscribe
+      end
     end
   end
 end

--- a/lib/yt/audit/version.rb
+++ b/lib/yt/audit/version.rb
@@ -1,5 +1,5 @@
 module Yt
   module Audit
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end

--- a/test/yt/audit_test.rb
+++ b/test/yt/audit_test.rb
@@ -3,23 +3,20 @@ require 'yt/audit'
 
 class Yt::AuditTest < Minitest::Test
   def setup
-    @good_channel_id = 'UCPCk_8dtVyR1lLHMBEILW4g'
-    @good_video_id = 'rF711XAtrVg' # temporarily use Budweiser
-
-    @bad_channel_id = 'UCQA5651nwDwKP2oLwv8hTkw'
-    @bad_video_id = 'Cq_Qo0uaIbI'
+    @good_video_id = 'iviMOnX8aks'
+    @bad_video_id = 'h5HrvPJGkL4'
   end
 
   def test_has_brand_anchoring
-    assert_equal true, Yt::Audit.has_brand_anchoring?(@good_video_id, 'Budweiser')
+    assert_equal true, Yt::Audit.has_brand_anchoring?(@good_video_id, 'Audit Good')
   end
 
   def test_brand_name_not_case_sensitive
-    assert_equal true, Yt::Audit.has_brand_anchoring?(@good_video_id, 'buDweIser')
+    assert_equal true, Yt::Audit.has_brand_anchoring?(@good_video_id, 'AudiT GOod')
   end
 
   def test_does_not_have_brand_anchoring
-    assert_equal false, Yt::Audit.has_brand_anchoring?(@bad_video_id, 'Budweiser')
+    assert_equal false, Yt::Audit.has_brand_anchoring?(@bad_video_id, 'Audit Good')
   end
 
   def test_has_info_cards
@@ -33,5 +30,14 @@ class Yt::AuditTest < Minitest::Test
   def test_invalid_video_id
     assert_raises(NoMethodError) { Yt::Audit.has_info_cards?('') }
     assert_raises(Yt::Errors::NoItems) { Yt::Audit.has_brand_anchoring?('', '') }
+    assert_raises(NoMethodError) { Yt::Audit.has_subscribe_annotations?('') }
+  end
+
+  def test_has_subscribe_annotations
+    assert_equal true, Yt::Audit.has_subscribe_annotations?(@good_video_id)
+  end
+
+  def test_does_not_have_subscribe_annotations
+    assert_equal false, Yt::Audit.has_subscribe_annotations?(@bad_video_id)
   end
 end


### PR DESCRIPTION
- Return true if the video has annotations with subscribe link
- Update test with specific custom-made test videos
- Remove temporary test code for error messages
