### PR TITLE
Audit end card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.1.4  - 2016.02.17
+
+* [FEATURE] Add `has_end_cards?`
+
 ## 0.1.3  - 2016.02.16
 
 * [FEATURE] Add `has_link_to_own_channel?`

--- a/README.md
+++ b/README.md
@@ -33,4 +33,6 @@ Yt::Audit.has_subscribe_annotations?('rF711XAtrVg')
 # => false
 Yt::Audit.has_link_to_own_channel?('rF711XAtrVg')
 # => false
+Yt::Audit.has_end_cards?('rF711XAtrVg')
+# => false
 ```

--- a/lib/yt/audit.rb
+++ b/lib/yt/audit.rb
@@ -39,5 +39,18 @@ module Yt
            .select {|word| Yt::URL.new(word).kind == :channel }
            .any? {|link| Yt::Channel.new(url: link).id == video.channel_id }
     end
+
+    # Audit end cards of a video
+    # @param [String] video_id of the video to audit.
+    # @return [Boolean] if the video has any annotation, other than info cards,
+    #   with a link in it, at the end of video, stays for more than 5 seconds.
+    def self.has_end_cards?(video_id)
+      video_duration = Yt::Video.new(id: video_id).duration
+      Yt::Annotations.for(video_id).any? do |annotation|
+        !annotation.is_a?(Yt::Annotations::Card) && annotation.link &&
+          annotation.ends_at.ceil == video_duration &&
+          video_duration - annotation.starts_at > 5
+      end
+    end
   end
 end

--- a/lib/yt/audit/version.rb
+++ b/lib/yt/audit/version.rb
@@ -1,5 +1,5 @@
 module Yt
   module Audit
-    VERSION = "0.1.3"
+    VERSION = "0.1.4"
   end
 end

--- a/test/yt/audit_test.rb
+++ b/test/yt/audit_test.rb
@@ -3,7 +3,7 @@ require 'yt/audit'
 
 class Yt::AuditTest < Minitest::Test
   def setup
-    @good_video_id = 'iviMOnX8aks'
+    @good_video_id = 'zPQxhP4KDdg'
     @bad_video_id = 'h5HrvPJGkL4'
   end
 
@@ -41,5 +41,13 @@ class Yt::AuditTest < Minitest::Test
 
   def test_does_not_have_youtube_association
     assert_equal false, Yt::Audit.has_link_to_own_channel?(@bad_video_id)
+  end
+
+  def test_has_end_cards
+    assert_equal true, Yt::Audit.has_end_cards?(@good_video_id)
+  end
+
+  def test_does_not_have_end_cards
+    assert_equal false, Yt::Audit.has_end_cards?(@bad_video_id)
   end
 end


### PR DESCRIPTION
Add `has_end_cards?` method to check if a given video has any annotation (except info card) with a link (to anywhere) in it, lasts more than 5 seconds, until the end of the video. See #63.

Change sample youtube video for testing.