### PR TITLE
Fix `has_end_cards?` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.1.5  - 2016.02.17
+
+* [BUGFIX] Fix `has_end_cards?` for cases when Float `ends_at` is
+  greater than Fixnum `duration`
+
 ## 0.1.4  - 2016.02.17
 
 * [FEATURE] Add `has_end_cards?`

--- a/lib/yt/audit.rb
+++ b/lib/yt/audit.rb
@@ -48,7 +48,7 @@ module Yt
       video_duration = Yt::Video.new(id: video_id).duration
       Yt::Annotations.for(video_id).any? do |annotation|
         !annotation.is_a?(Yt::Annotations::Card) && annotation.link &&
-          annotation.ends_at.ceil == video_duration &&
+          (annotation.ends_at.floor..annotation.ends_at.ceil).include?(video_duration) &&
           video_duration - annotation.starts_at > 5
       end
     end

--- a/lib/yt/audit/version.rb
+++ b/lib/yt/audit/version.rb
@@ -1,5 +1,5 @@
 module Yt
   module Audit
-    VERSION = "0.1.4"
+    VERSION = "0.1.5"
   end
 end

--- a/test/yt/audit_test.rb
+++ b/test/yt/audit_test.rb
@@ -50,4 +50,8 @@ class Yt::AuditTest < Minitest::Test
   def test_does_not_have_end_cards
     assert_equal false, Yt::Audit.has_end_cards?(@bad_video_id)
   end
+
+  def test_has_end_cards_ends_after_video_duration
+    assert_equal true, Yt::Audit.has_end_cards?("Hskp8OlCTwU")
+  end
 end


### PR DESCRIPTION
`ends_at` (Float) of some annotations come after `duration` (Fixnum) of its video