### PR TITLE
Add `run` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.2.0  - 2016.02.18
+
+**How to upgrade**
+
+If your code calls any of `has_end_cards?`, `has_link_to_own_channel?`, `has_subscribe_annotations?`, `has_brand_anchoring?`, or `has_info_cards?` method with a video id, they are removed. Instead, call `run` method from a `Yt::Audit` instance to get information of a channel.
+
+* [FEATURE] Add `run` method to audit a channel and count how many videos have each audit subject out of its recent 10 videos.
+* [REMOVAL] Remove `has_end_cards?`
+* [REMOVAL] Remove `has_link_to_own_channel?`
+* [REMOVAL] Remove `has_subscribe_annotations?`
+* [REMOVAL] Remove `has_brand_anchoring?`
+* [REMOVAL] Remove `has_info_cards?`
+
 ## 0.1.5  - 2016.02.17
 
 * [BUGFIX] Fix `has_end_cards?` for cases when Float `ends_at` is

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Yt::Audit
 
-Welcome! This is a Ruby library you can audit a YouTube video.
+Welcome! This is a Ruby library you can audit a YouTube channel.
 
 The **source code** is available on [GitHub](https://github.com/Fullscreen/yt-audit) and the **documentation** on [RubyDoc](http://www.rubydoc.info/github/fullscreen/yt-audit/master/Yt/Audit).
 
@@ -16,7 +16,7 @@ The **source code** is available on [GitHub](https://github.com/Fullscreen/yt-au
 
     $ bin/setup
 
-    $ YT_API_KEY="123456789012345678901234567890" rake
+    $ YT_API_KEY="123456789012345678901234567890123456789" rake
     $ open coverage/index.html
 
     $ yardoc
@@ -24,15 +24,26 @@ The **source code** is available on [GitHub](https://github.com/Fullscreen/yt-au
 
 ## Usage
 
+`run` method returns an array of objects. It uses channel title as brand name, and 10 recent videos of channel, currently.
+
 ```ruby
-Yt::Audit.has_info_cards?('rF711XAtrVg')
-# => true
-Yt::Audit.has_brand_anchoring?('rF711XAtrVg', 'Budweiser')
-# => true
-Yt::Audit.has_subscribe_annotations?('rF711XAtrVg')
-# => false
-Yt::Audit.has_link_to_own_channel?('rF711XAtrVg')
-# => false
-Yt::Audit.has_end_cards?('rF711XAtrVg')
-# => false
+audit = Yt::Audit.new(channel_id: 'UCPCk_8dtVyR1lLHMBEILW4g')
+# => #<Yt::Audit:0x007f94ec8050b0 @channel_id="UCPCk_8dtVyR1lLHMBEILW4g">
+audit.run
+# => [#<Yt::VideoAudit::InfoCard:0x007f94ec8c6f30 @videos=[...]>, #<Yt::VideoAudit::BrandAnchoring...>, #<Yt::VideoAudit::SubscribeAnnotation...>, #<Yt::VideoAudit::YoutubeAssociation...>, #<Yt::VideoAudit::EndCard...>]
+```
+
+You can call four available methods `total_count`, `valid_count`, `title`, and `description` from each `Yt::VideoAudit` object.
+
+```ruby
+video_audit = audit.run[0]
+# => #<Yt::VideoAudit::InfoCard:0x007f94ec979ab8 @videos=[...]>
+video_audit.total_count
+# => 10
+video_audit.valid_count
+# => 10
+video_audit.title
+# => "Info Cards"
+video_audit.description
+# => "The number of videos with an info card"
 ```

--- a/bin/yt-audit
+++ b/bin/yt-audit
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+
+begin
+  require 'yt/audit'
+rescue LoadError
+  require 'rubygems'
+  require 'yt/audit'
+end
+
+channel_id = ARGV[0] || 'UCKM-eG7PBcw3flaBvd0q2TQ'
+audit = Yt::Audit.new(channel_id: channel_id)
+puts "Channel: https://www.youtube.com/channel/#{channel_id}"
+audit.run.each do |video_audit|
+  puts
+  puts "#{video_audit.description}"
+  puts "#{video_audit.title}: #{video_audit.valid_count} out of #{video_audit.total_count}"
+end
+

--- a/lib/yt/audit.rb
+++ b/lib/yt/audit.rb
@@ -1,56 +1,35 @@
 require 'yt'
 require 'yt/annotations'
+require 'yt/video_audit/info_card'
+require 'yt/video_audit/brand_anchoring'
+require 'yt/video_audit/subscribe_annotation'
+require 'yt/video_audit/youtube_association'
+require 'yt/video_audit/end_card'
 
 module Yt
-  module Audit
-    # Audit any info card of a video
-    # @param [String] video_id the video to audit.
-    # @return [Boolean] if the video has any info card.
-    def self.has_info_cards?(video_id)
-      Yt::Annotations.for(video_id).any? do |annotation|
-        annotation.is_a? Yt::Annotations::Card
-      end
+  class Audit
+    def initialize(channel_id:)
+      @channel_id = channel_id
     end
 
-    # Audit brand anchoring of a video
-    # @param [String] video_id the video to audit.
-    # @param [String] brand name of the video to audit.
-    # @return [Boolean] if the video title includes brand name.
-    def self.has_brand_anchoring?(video_id, brand)
-      video_title = Yt::Video.new(id: video_id).title
-      !!video_title[/#{brand}/i]
+    def run
+      [
+        Yt::VideoAudit::InfoCard.new(videos: videos),
+        Yt::VideoAudit::BrandAnchoring.new(videos: videos, brand: channel.title),
+        Yt::VideoAudit::SubscribeAnnotation.new(videos: videos),
+        Yt::VideoAudit::YoutubeAssociation.new(videos: videos),
+        Yt::VideoAudit::EndCard.new(videos: videos)
+      ]
     end
 
-    # Audit any subscribe annotation of a video
-    # @param [String] video_id the video to audit.
-    # @return [Boolean] if the video has any link to subscribe in the annotations.
-    def self.has_subscribe_annotations?(video_id)
-      Yt::Annotations.for(video_id).any? do |annotation|
-        annotation.link && annotation.link[:type] == :subscribe
-      end
+  private
+
+    def videos
+      @videos ||= channel.videos.first 10
     end
 
-    # Audit youtube association of a video
-    # @param [String] video_id the video to audit.
-    # @return [Boolean] if the video description has link to its own channel.
-    def self.has_link_to_own_channel?(video_id)
-      video = Yt::Video.new(id: video_id)
-      video.description.split(' ')
-           .select {|word| Yt::URL.new(word).kind == :channel }
-           .any? {|link| Yt::Channel.new(url: link).id == video.channel_id }
-    end
-
-    # Audit end cards of a video
-    # @param [String] video_id of the video to audit.
-    # @return [Boolean] if the video has any annotation, other than info cards,
-    #   with a link in it, at the end of video, stays for more than 5 seconds.
-    def self.has_end_cards?(video_id)
-      video_duration = Yt::Video.new(id: video_id).duration
-      Yt::Annotations.for(video_id).any? do |annotation|
-        !annotation.is_a?(Yt::Annotations::Card) && annotation.link &&
-          (annotation.ends_at.floor..annotation.ends_at.ceil).include?(video_duration) &&
-          video_duration - annotation.starts_at > 5
-      end
+    def channel
+      @channel ||= Yt::Channel.new id: @channel_id
     end
   end
 end

--- a/lib/yt/audit/version.rb
+++ b/lib/yt/audit/version.rb
@@ -1,5 +1,5 @@
 module Yt
-  module Audit
-    VERSION = "0.1.5"
+  class Audit
+    VERSION = "0.2.0"
   end
 end

--- a/lib/yt/video_audit/base.rb
+++ b/lib/yt/video_audit/base.rb
@@ -1,0 +1,19 @@
+module Yt
+  module VideoAudit
+    class Base
+      def initialize(options = {})
+        @videos = options[:videos]
+      end
+
+      # @return [Fixnum] number of all given videos.
+      def total_count
+        @videos.size
+      end
+
+      # @return [Fixnum] number of videos satisfy given condition.
+      def valid_count
+        @videos.count {|video| valid? video}
+      end
+    end
+  end
+end

--- a/lib/yt/video_audit/brand_anchoring.rb
+++ b/lib/yt/video_audit/brand_anchoring.rb
@@ -1,0 +1,27 @@
+require 'yt/video_audit/base'
+
+module Yt
+  module VideoAudit
+    # Count how many subject videos include its brand name in the title.
+    class BrandAnchoring < Base
+      def initialize(options = {})
+        super
+        @brand = options[:brand]
+      end
+
+      def title
+        'Brand Anchoring'
+      end
+
+      def description
+        'The number of videos with the brand name in the title'
+      end
+
+    private
+
+      def valid?(video)
+        !!video.title[/#{@brand}/i]
+      end
+    end
+  end
+end

--- a/lib/yt/video_audit/end_card.rb
+++ b/lib/yt/video_audit/end_card.rb
@@ -1,0 +1,29 @@
+require 'yt/video_audit/base'
+
+module Yt
+  module VideoAudit
+    # Count how many subject videos have any end card. An end card
+    # can be described as an annotation, not an info card, with a link in it,
+    # at the end of video, stays for more than 5 seconds.
+    class EndCard < Base
+      def title
+        'Possible End Card Annotations'
+      end
+
+      def description
+        'The number of videos with a link annotation'\
+        ' longer than 5 seconds, not an info card, at the end of its duration'
+      end
+
+    private
+
+      def valid?(video)
+        Yt::Annotations.for(video.id).any? do |annotation|
+          !annotation.is_a?(Yt::Annotations::Card) && annotation.link &&
+            (annotation.ends_at.floor..annotation.ends_at.ceil).include?(video.duration) &&
+            video.duration - annotation.starts_at > 5
+        end
+      end
+    end
+  end
+end

--- a/lib/yt/video_audit/info_card.rb
+++ b/lib/yt/video_audit/info_card.rb
@@ -1,0 +1,24 @@
+require 'yt/video_audit/base'
+
+module Yt
+  module VideoAudit
+    # Count how many subject videos have an info card.
+    class InfoCard < Base
+      def title
+        'Info Cards'
+      end
+
+      def description
+        'The number of videos with an info card'
+      end
+
+    private
+
+      def valid?(video)
+        Yt::Annotations.for(video.id).any? do |annotation|
+          annotation.is_a? Yt::Annotations::Card
+        end
+      end
+    end
+  end
+end

--- a/lib/yt/video_audit/subscribe_annotation.rb
+++ b/lib/yt/video_audit/subscribe_annotation.rb
@@ -1,0 +1,25 @@
+require 'yt/video_audit/base'
+
+module Yt
+  module VideoAudit
+    # Count how many subject videos have an annotation
+    # with a subscribe link.
+    class SubscribeAnnotation < Base
+      def title
+        'Subscribe Annotations'
+      end
+
+      def description
+        'The number of videos with a link to subscribe in its annotations'
+      end
+
+    private
+
+      def valid?(video)
+        Yt::Annotations.for(video.id).any? do |annotation|
+          annotation.link && annotation.link[:type] == :subscribe
+        end
+      end
+    end
+  end
+end

--- a/lib/yt/video_audit/youtube_association.rb
+++ b/lib/yt/video_audit/youtube_association.rb
@@ -1,0 +1,25 @@
+require 'yt/video_audit/base'
+
+module Yt
+  module VideoAudit
+    # Count how many videos have video description includes
+    # a link to its own channel.
+    class YoutubeAssociation < Base
+      def title
+        'YouTube Association'
+      end
+
+      def description
+        'The number of videos with description has a link to its own channel'
+      end
+
+    private
+
+      def valid?(video)
+        video.description.split(' ')
+             .select {|word| Yt::URL.new(word).kind == :channel }
+             .any? {|link| Yt::Channel.new(url: link).id == video.channel_id }
+      end
+    end
+  end
+end

--- a/test/yt/audit_test.rb
+++ b/test/yt/audit_test.rb
@@ -2,56 +2,28 @@ require 'test_helper'
 require 'yt/audit'
 
 class Yt::AuditTest < Minitest::Test
-  def setup
-    @good_video_id = 'zPQxhP4KDdg'
-    @bad_video_id = 'h5HrvPJGkL4'
-  end
+  def test_channel_audit
+    audit = Yt::Audit.new(channel_id: 'UCKM-eG7PBcw3flaBvd0q2TQ')
+    result = audit.run
 
-  def test_has_brand_anchoring
-    assert_equal true, Yt::Audit.has_brand_anchoring?(@good_video_id, 'Audit Good')
-  end
+    assert_equal 'Info Cards', result[0].title
+    assert_equal 2, result[0].valid_count
+    assert_equal 4, result[0].total_count
 
-  def test_brand_name_not_case_sensitive
-    assert_equal true, Yt::Audit.has_brand_anchoring?(@good_video_id, 'AudiT GOod')
-  end
+    assert_equal 'Brand Anchoring', result[1].title
+    assert_equal 2, result[1].valid_count
+    assert_equal 4, result[1].total_count
 
-  def test_does_not_have_brand_anchoring
-    assert_equal false, Yt::Audit.has_brand_anchoring?(@bad_video_id, 'Audit Good')
-  end
+    assert_equal 'Subscribe Annotations', result[2].title
+    assert_equal 2, result[2].valid_count
+    assert_equal 4, result[2].total_count
 
-  def test_has_info_cards
-    assert_equal true, Yt::Audit.has_info_cards?(@good_video_id)
-  end
+    assert_equal 'YouTube Association', result[3].title
+    assert_equal 2, result[3].valid_count
+    assert_equal 4, result[3].total_count
 
-  def test_does_not_have_info_cards
-    assert_equal false, Yt::Audit.has_info_cards?(@bad_video_id)
-  end
-
-  def test_has_subscribe_annotations
-    assert_equal true, Yt::Audit.has_subscribe_annotations?(@good_video_id)
-  end
-
-  def test_does_not_have_subscribe_annotations
-    assert_equal false, Yt::Audit.has_subscribe_annotations?(@bad_video_id)
-  end
-
-  def test_has_youtube_association
-    assert_equal true, Yt::Audit.has_link_to_own_channel?(@good_video_id)
-  end
-
-  def test_does_not_have_youtube_association
-    assert_equal false, Yt::Audit.has_link_to_own_channel?(@bad_video_id)
-  end
-
-  def test_has_end_cards
-    assert_equal true, Yt::Audit.has_end_cards?(@good_video_id)
-  end
-
-  def test_does_not_have_end_cards
-    assert_equal false, Yt::Audit.has_end_cards?(@bad_video_id)
-  end
-
-  def test_has_end_cards_ends_after_video_duration
-    assert_equal true, Yt::Audit.has_end_cards?("Hskp8OlCTwU")
+    assert_equal 'Possible End Card Annotations', result[4].title
+    assert_equal 1, result[4].valid_count
+    assert_equal 4, result[4].total_count
   end
 end


### PR DESCRIPTION
+ Audit 10 videos of a channel with channel title as its brand name.
+ Remove methods: `has_end_cards?`, `has_link_to_own_channel?`, `has_subscribe_annotations?`, `has_brand_anchoring?`, `has_info_cards?` 
+ Add `Yt::VideoAudit` module for all types of video audit as classes: `BrandAnchoring`, `EndCard`, `InfoCard`, `SubscribeAnnotation`, `YoutubeAssociation`
+ Bump version to 0.2.0
+ Add bin/yt-audit command line tool