### PR TITLE
Count playlists with description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.2.1  - 2016.02.19
+
+* [FEATURE] Add `PlaylistAudit::Descripton` for `run` to also count playlists with a description.
+
 ## 0.2.0  - 2016.02.18
 
 **How to upgrade**

--- a/README.md
+++ b/README.md
@@ -30,20 +30,20 @@ The **source code** is available on [GitHub](https://github.com/Fullscreen/yt-au
 audit = Yt::Audit.new(channel_id: 'UCPCk_8dtVyR1lLHMBEILW4g')
 # => #<Yt::Audit:0x007f94ec8050b0 @channel_id="UCPCk_8dtVyR1lLHMBEILW4g">
 audit.run
-# => [#<Yt::VideoAudit::InfoCard:0x007f94ec8c6f30 @videos=[...]>, #<Yt::VideoAudit::BrandAnchoring...>, #<Yt::VideoAudit::SubscribeAnnotation...>, #<Yt::VideoAudit::YoutubeAssociation...>, #<Yt::VideoAudit::EndCard...>]
+# => [#<Yt::VideoAudit::InfoCard:0x007f94ec8c6f30 @videos=[...]>, #<Yt::VideoAudit::BrandAnchoring...>, #<Yt::VideoAudit::SubscribeAnnotation...>, #<Yt::VideoAudit::YoutubeAssociation...>, #<Yt::VideoAudit::EndCard...>, #<Yt::PlaylistAudit::Description...>]
 ```
 
-You can call four available methods `total_count`, `valid_count`, `title`, and `description` from each `Yt::VideoAudit` object.
+You can call four available methods `total_count`, `valid_count`, `title`, and `description` from each `Yt::VideoAudit` or `Yt::PlaylistAudit` object.
 
 ```ruby
-video_audit = audit.run[0]
+audit_item = audit.run[0]
 # => #<Yt::VideoAudit::InfoCard:0x007f94ec979ab8 @videos=[...]>
-video_audit.total_count
+audit_item.total_count
 # => 10
-video_audit.valid_count
+audit_item.valid_count
 # => 10
-video_audit.title
+audit_item.title
 # => "Info Cards"
-video_audit.description
+audit_item.description
 # => "The number of videos with an info card"
 ```

--- a/bin/yt-audit
+++ b/bin/yt-audit
@@ -10,9 +10,9 @@ end
 channel_id = ARGV[0] || 'UCKM-eG7PBcw3flaBvd0q2TQ'
 audit = Yt::Audit.new(channel_id: channel_id)
 puts "Channel: https://www.youtube.com/channel/#{channel_id}"
-audit.run.each do |video_audit|
+audit.run.each do |audit_item|
   puts
-  puts "#{video_audit.description}"
-  puts "#{video_audit.title}: #{video_audit.valid_count} out of #{video_audit.total_count}"
+  puts "#{audit_item.description}"
+  puts "#{audit_item.title}: #{audit_item.valid_count} out of #{audit_item.total_count}"
 end
 

--- a/lib/yt/audit.rb
+++ b/lib/yt/audit.rb
@@ -5,6 +5,7 @@ require 'yt/video_audit/brand_anchoring'
 require 'yt/video_audit/subscribe_annotation'
 require 'yt/video_audit/youtube_association'
 require 'yt/video_audit/end_card'
+require 'yt/playlist_audit/description'
 
 module Yt
   class Audit
@@ -18,11 +19,16 @@ module Yt
         Yt::VideoAudit::BrandAnchoring.new(videos: videos, brand: channel.title),
         Yt::VideoAudit::SubscribeAnnotation.new(videos: videos),
         Yt::VideoAudit::YoutubeAssociation.new(videos: videos),
-        Yt::VideoAudit::EndCard.new(videos: videos)
+        Yt::VideoAudit::EndCard.new(videos: videos),
+        Yt::PlaylistAudit::Description.new(playlists: playlists)
       ]
     end
 
   private
+
+    def playlists
+      @playlists ||= channel.playlists.first 10
+    end
 
     def videos
       @videos ||= channel.videos.first 10

--- a/lib/yt/audit/version.rb
+++ b/lib/yt/audit/version.rb
@@ -1,5 +1,5 @@
 module Yt
   class Audit
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end

--- a/lib/yt/playlist_audit/description.rb
+++ b/lib/yt/playlist_audit/description.rb
@@ -1,0 +1,32 @@
+module Yt
+  module PlaylistAudit
+    # Count how many playlists have its description.
+    class Description
+      def initialize(playlists:)
+        @playlists = playlists
+      end
+
+      def total_count
+        @playlists.size
+      end
+
+      def valid_count
+        @playlists.count {|playlist| valid? playlist}
+      end
+
+      def title
+        'Playlist Description'
+      end
+
+      def description
+        'The number of playlists with description'
+      end
+
+    private
+
+      def valid?(playlist)
+        !playlist.description.empty?
+      end
+    end
+  end
+end

--- a/test/yt/audit_test.rb
+++ b/test/yt/audit_test.rb
@@ -25,5 +25,9 @@ class Yt::AuditTest < Minitest::Test
     assert_equal 'Possible End Card Annotations', result[4].title
     assert_equal 1, result[4].valid_count
     assert_equal 4, result[4].total_count
+
+    assert_equal 'Playlist Description', result[5].title
+    assert_equal 1, result[5].valid_count
+    assert_equal 2, result[5].total_count
   end
 end


### PR DESCRIPTION
Add `Yt::PlaylistAudit::Description` class
Bump version to 0.2.1
use `audit_item` instead of `video_audit` in the usage
