### PR TITLE
Correctly find youtube association when video description is long

### DIFF
--- a/lib/yt/audit.rb
+++ b/lib/yt/audit.rb
@@ -31,7 +31,7 @@ module Yt
     end
 
     def videos
-      @videos ||= channel.videos.first 10
+      @videos ||= channel.videos.includes(:snippet).first 10
     end
 
     def channel

--- a/test/yt/audit_test.rb
+++ b/test/yt/audit_test.rb
@@ -3,6 +3,7 @@ require 'yt/audit'
 
 class Yt::AuditTest < Minitest::Test
   def test_channel_audit
+    skip
     audit = Yt::Audit.new(channel_id: 'UCKM-eG7PBcw3flaBvd0q2TQ')
     result = audit.run
 
@@ -29,5 +30,13 @@ class Yt::AuditTest < Minitest::Test
     assert_equal 'Playlist Description', result[5].title
     assert_equal 1, result[5].valid_count
     assert_equal 2, result[5].total_count
+  end
+
+  def test_youtube_association_of_HollywoodGameNight
+    audit = Yt::Audit.new(channel_id: 'UCpBkBMO8IbYAMdtYNaMxKgQ')
+    result = audit.run
+    assert_equal 'YouTube Association', result[3].title
+    assert_equal 10, result[3].valid_count
+    assert_equal 10, result[3].total_count
   end
 end

--- a/test/yt/audit_test.rb
+++ b/test/yt/audit_test.rb
@@ -3,7 +3,6 @@ require 'yt/audit'
 
 class Yt::AuditTest < Minitest::Test
   def test_channel_audit
-    skip
     audit = Yt::Audit.new(channel_id: 'UCKM-eG7PBcw3flaBvd0q2TQ')
     result = audit.run
 


### PR DESCRIPTION
`yt_channel.videos` respond with snippet of truncated description of each video, it needed `videos` request with `yt_channel.videos.includes(:snippet)` 