### PR TITLE
define Audit instance with a Channel object, instead of channel_id string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,19 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.3.0  - 2016.03.01
+
+**How to upgrade**
+
+When your code defines an `Yt::Audit` object, it should be initialized with a `Yt::Channel` object as `channel:` argument. It used to accept `channel_id` string directly but now your code should define a channel with it first.
+
+* [ENHANCEMENT] Optionally send in `Yt::Collections::Videos` or `Yt::Collections::Playlists` object as arguments of an `Yt::Audit`, accompanied with `Yt::Models::Channel` object of yt.
+* [ENHANCEMENT] Send in brand name as an optional argument.
+* [BUGFIX] Fix videos input with longer description, for Youtube Association.
+
 ## 0.2.2  - 2016.02.24
 
-## [BUGFIX] Fix condition of Info Card
+* [BUGFIX] Fix condition of Info Card
 
 ## 0.2.1  - 2016.02.19
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,14 @@ The **source code** is available on [GitHub](https://github.com/Fullscreen/yt-au
 
 ## Usage
 
-`run` method returns an array of objects. It uses channel title as brand name, and 10 recent videos of channel, currently.
+`run` method returns an array of objects. `Yt::Audit` should be initialized with a `Yt::Channel` object of [yt](https://github.com/Fullscreen/yt) as `channel`.
+
+It can also have videos, brand name, and playlists as optional, but by default it uses maximum 10 recent videos of channel as `videos`, channel title as `brand` and maximum 10 recent playlists as `playlists` keyword argument.
 
 ```ruby
-audit = Yt::Audit.new(channel_id: 'UCPCk_8dtVyR1lLHMBEILW4g')
-# => #<Yt::Audit:0x007f94ec8050b0 @channel_id="UCPCk_8dtVyR1lLHMBEILW4g">
+channel = Yt::Channel.new(id: 'UCPCk_8dtVyR1lLHMBEILW4g')
+audit = Yt::Audit.new(channel: channel)
+# => #<Yt::Audit:0x007ffbb43fe780 @channel=#<Yt::Models::Channel...>, @videos=[...], @playlists=[...], @brand="budweiser">
 audit.run
 # => [#<Yt::VideoAudit::InfoCard:0x007f94ec8c6f30 @videos=[...]>, #<Yt::VideoAudit::BrandAnchoring...>, #<Yt::VideoAudit::SubscribeAnnotation...>, #<Yt::VideoAudit::YoutubeAssociation...>, #<Yt::VideoAudit::EndCard...>, #<Yt::PlaylistAudit::Description...>]
 ```

--- a/bin/yt-audit
+++ b/bin/yt-audit
@@ -8,8 +8,9 @@ rescue LoadError
 end
 
 channel_id = ARGV[0] || 'UCKM-eG7PBcw3flaBvd0q2TQ'
-audit = Yt::Audit.new(channel_id: channel_id)
 puts "Channel: https://www.youtube.com/channel/#{channel_id}"
+channel = Yt::Channel.new(id: channel_id)
+audit = Yt::Audit.new(channel: channel)
 audit.run.each do |audit_item|
   puts
   puts "#{audit_item.description}"

--- a/lib/yt/audit.rb
+++ b/lib/yt/audit.rb
@@ -9,33 +9,22 @@ require 'yt/playlist_audit/description'
 
 module Yt
   class Audit
-    def initialize(channel_id:)
-      @channel_id = channel_id
+    def initialize(channel:, videos: nil, playlists: nil, brand: nil)
+      @channel = channel
+      @videos = videos || channel.videos.includes(:snippet).first(10)
+      @playlists = playlists || channel.playlists.first(10)
+      @brand = brand || channel.title
     end
 
     def run
       [
-        Yt::VideoAudit::InfoCard.new(videos: videos),
-        Yt::VideoAudit::BrandAnchoring.new(videos: videos, brand: channel.title),
-        Yt::VideoAudit::SubscribeAnnotation.new(videos: videos),
-        Yt::VideoAudit::YoutubeAssociation.new(videos: videos),
-        Yt::VideoAudit::EndCard.new(videos: videos),
-        Yt::PlaylistAudit::Description.new(playlists: playlists)
+        Yt::VideoAudit::InfoCard.new(videos: @videos),
+        Yt::VideoAudit::BrandAnchoring.new(videos: @videos, brand: @brand),
+        Yt::VideoAudit::SubscribeAnnotation.new(videos: @videos),
+        Yt::VideoAudit::YoutubeAssociation.new(videos: @videos),
+        Yt::VideoAudit::EndCard.new(videos: @videos),
+        Yt::PlaylistAudit::Description.new(playlists: @playlists)
       ]
-    end
-
-  private
-
-    def playlists
-      @playlists ||= channel.playlists.first 10
-    end
-
-    def videos
-      @videos ||= channel.videos.includes(:snippet).first 10
-    end
-
-    def channel
-      @channel ||= Yt::Channel.new id: @channel_id
     end
   end
 end

--- a/lib/yt/audit.rb
+++ b/lib/yt/audit.rb
@@ -31,7 +31,7 @@ module Yt
     end
 
     def videos
-      @videos ||= channel.videos.first 10
+      @videos ||= channel.videos.includes(:snippet).first 10
     end
 
     def channel

--- a/lib/yt/audit/version.rb
+++ b/lib/yt/audit/version.rb
@@ -1,5 +1,5 @@
 module Yt
   class Audit
-    VERSION = "0.2.2"
+    VERSION = "0.3.0"
   end
 end

--- a/lib/yt/playlist_audit/description.rb
+++ b/lib/yt/playlist_audit/description.rb
@@ -2,8 +2,8 @@ module Yt
   module PlaylistAudit
     # Count how many playlists have its description.
     class Description
-      def initialize(playlists:)
-        @playlists = playlists
+      def initialize(options={})
+        @playlists = options[:playlists]
       end
 
       def total_count

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,3 +8,9 @@ SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new [
 SimpleCov.start
 
 require 'minitest/autorun'
+
+require 'yt/audit'
+
+Yt.configure do |config|
+  config.log_level = :debug
+end

--- a/test/yt/audit_test.rb
+++ b/test/yt/audit_test.rb
@@ -12,26 +12,32 @@ class Yt::AuditTest < Minitest::Test
     result = audit.run
 
     assert_equal 'Info Cards', result[0].title
+    assert_equal "The number of videos with an info card", result[0].description
     assert_equal 2, result[0].valid_count
     assert_equal 5, result[0].total_count
 
     assert_equal 'Brand Anchoring', result[1].title
+    assert_equal "The number of videos with the brand name in the title", result[1].description
     assert_equal 3, result[1].valid_count
     assert_equal 5, result[1].total_count
 
     assert_equal 'Subscribe Annotations', result[2].title
+    assert_equal "The number of videos with a link to subscribe in its annotations", result[2].description
     assert_equal 2, result[2].valid_count
     assert_equal 5, result[2].total_count
 
     assert_equal 'YouTube Association', result[3].title
+    assert_equal "The number of videos with description has a link to its own channel", result[3].description
     assert_equal 2, result[3].valid_count
     assert_equal 5, result[3].total_count
 
     assert_equal 'Possible End Card Annotations', result[4].title
+    assert_equal "The number of videos with a link annotation longer than 5 seconds, not an info card, at the end of its duration", result[4].description
     assert_equal 1, result[4].valid_count
     assert_equal 5, result[4].total_count
 
     assert_equal 'Playlist Description', result[5].title
+    assert_equal "The number of playlists with description", result[5].description
     assert_equal 1, result[5].valid_count
     assert_equal 4, result[5].total_count
   end

--- a/test/yt/audit_test.rb
+++ b/test/yt/audit_test.rb
@@ -3,6 +3,7 @@ require 'yt/audit'
 
 class Yt::AuditTest < Minitest::Test
   def test_channel_audit
+    skip
     audit = Yt::Audit.new(channel_id: 'UCKM-eG7PBcw3flaBvd0q2TQ')
     result = audit.run
 
@@ -29,5 +30,13 @@ class Yt::AuditTest < Minitest::Test
     assert_equal 'Playlist Description', result[5].title
     assert_equal 1, result[5].valid_count
     assert_equal 2, result[5].total_count
+  end
+
+  def test_youtube_association_of_HollywoodGameNight
+    audit = Yt::Audit.new(channel_id: 'UCpBkBMO8IbYAMdtYNaMxKgQ')
+    result = audit.run
+    assert_equal 'YouTube Association', result[3].title
+    assert_equal 10, result[3].valid_count
+    assert_equal 10, result[3].total_count
   end
 end

--- a/test/yt/audit_test.rb
+++ b/test/yt/audit_test.rb
@@ -3,7 +3,6 @@ require 'yt/audit'
 
 class Yt::AuditTest < Minitest::Test
   def test_channel_audit
-    skip
     audit = Yt::Audit.new(channel_id: 'UCKM-eG7PBcw3flaBvd0q2TQ')
     result = audit.run
 

--- a/test/yt/audit_test.rb
+++ b/test/yt/audit_test.rb
@@ -1,9 +1,14 @@
 require 'test_helper'
-require 'yt/audit'
 
 class Yt::AuditTest < Minitest::Test
+
+  def setup
+    channel_id = 'UCKM-eG7PBcw3flaBvd0q2TQ'
+    @channel = Yt::Channel.new(id: channel_id)
+  end
+
   def test_channel_audit
-    audit = Yt::Audit.new(channel_id: 'UCKM-eG7PBcw3flaBvd0q2TQ')
+    audit = Yt::Audit.new(channel: @channel)
     result = audit.run
 
     assert_equal 'Info Cards', result[0].title
@@ -28,14 +33,45 @@ class Yt::AuditTest < Minitest::Test
 
     assert_equal 'Playlist Description', result[5].title
     assert_equal 1, result[5].valid_count
+    assert_equal 4, result[5].total_count
+  end
+
+  def test_channel_audit_with_videos_argument
+    videos = @channel.videos.includes(:snippet).first(4)
+    audit = Yt::Audit.new(channel: @channel, videos: videos)
+    result = audit.run
+
+    assert_equal 'Info Cards', result[0].title
+    assert_equal 4, result[0].total_count
+
+    assert_equal 'Brand Anchoring', result[1].title
+    assert_equal 4, result[1].total_count
+
+    assert_equal 'Subscribe Annotations', result[2].title
+    assert_equal 4, result[2].total_count
+
+    assert_equal 'YouTube Association', result[3].title
+    assert_equal 4, result[3].total_count
+
+    assert_equal 'Possible End Card Annotations', result[4].title
+    assert_equal 4, result[4].total_count
+  end
+
+  def test_channel_audit_with_playlists_argument
+    playlists = @channel.playlists.first(2)
+    audit = Yt::Audit.new(channel: @channel, playlists: playlists)
+    result = audit.run
+
+    assert_equal 'Playlist Description', result[5].title
     assert_equal 2, result[5].total_count
   end
 
-  def test_youtube_association_of_HollywoodGameNight
-    audit = Yt::Audit.new(channel_id: 'UCpBkBMO8IbYAMdtYNaMxKgQ')
+  def test_channel_audit_with_brand_argument
+    audit = Yt::Audit.new(channel: @channel, brand: 'Test')
     result = audit.run
-    assert_equal 'YouTube Association', result[3].title
-    assert_equal 10, result[3].valid_count
-    assert_equal 10, result[3].total_count
+
+    assert_equal 'Brand Anchoring', result[1].title
+    assert_equal 2, result[1].valid_count
+    assert_equal 5, result[1].total_count
   end
 end


### PR DESCRIPTION
Instead of `Yt::Audit.new(channel_id: "string")`, Use following 4 arguments:

+ channel: a `Yt::Models::Channel` object, not optional.
+ videos: a `Yt::Collections::Videos` object, optional, by default `channel.videos.includes(:snippet).first(10)`
+ playlists: a `Yt::Collections::Playlists` object, optional, by default `channel.playlists.first(10)`
+ brand: a string for a brand name, optional, by default `channel.title`