### PR TITLE
Add rescue statement in valid? condition of YoutubeAssociation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.3.1  - 2016.04.04
+
+* [BUGFIX] Fix condition of Youtube Association for invalid channel urls on the description.
+
 ## 0.3.0  - 2016.03.01
 
 **How to upgrade**

--- a/lib/yt/audit/version.rb
+++ b/lib/yt/audit/version.rb
@@ -1,5 +1,5 @@
 module Yt
   class Audit
-    VERSION = "0.3.0"
+    VERSION = "0.3.1"
   end
 end

--- a/lib/yt/video_audit/youtube_association.rb
+++ b/lib/yt/video_audit/youtube_association.rb
@@ -18,7 +18,12 @@ module Yt
       def valid?(video)
         video.description.split(' ')
              .select {|word| Yt::URL.new(word).kind == :channel }
-             .any? {|link| Yt::Channel.new(url: link).id == video.channel_id }
+             .any? {|link| channel_id(link) == video.channel_id }
+      end
+
+      def channel_id(url)
+        Yt::Channel.new(url: url).id
+      rescue Yt::Errors::NoItems
       end
     end
   end


### PR DESCRIPTION
There was a channel had some videos their description includes truncated channel url, and channel object with this url returned an error when `id` called. By `rescue` of `Yt::Errors::NoItems` error, those addresses are only regarded as an address which is not of own channel. (They should be)