### PR TITLE
Require yt 0.29.0 or higher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.4.0  - 2017.02.27
+
+**How to upgrade**
+
+If your code depends on the `yt` gem, ensure you use version 0.29.0 or higher.
+
+* [ENHANCEMENT] Use new `yt-url` gem, extracted from `yt`
+
 ## 0.3.2  - 2017.02.26
 
 * [ENHANCEMENT] Don't limit Yt dependency to 0.25.x

--- a/lib/yt/audit.rb
+++ b/lib/yt/audit.rb
@@ -1,5 +1,6 @@
 require 'yt'
 require 'yt/annotations'
+require 'yt/url'
 require 'yt/video_audit/info_card'
 require 'yt/video_audit/brand_anchoring'
 require 'yt/video_audit/subscribe_annotation'

--- a/lib/yt/audit/version.rb
+++ b/lib/yt/audit/version.rb
@@ -1,5 +1,5 @@
 module Yt
   class Audit
-    VERSION = "0.3.2"
+    VERSION = '0.4.0'
   end
 end

--- a/lib/yt/video_audit/youtube_association.rb
+++ b/lib/yt/video_audit/youtube_association.rb
@@ -16,13 +16,16 @@ module Yt
     private
 
       def valid?(video)
-        video.description.split(' ')
-             .select {|word| Yt::URL.new(word).kind == :channel }
-             .any? {|link| channel_id(link) == video.channel_id }
+        video.description.split(' ').any? do |word|
+          if Yt::URL::CHANNEL_PATTERNS.any?{|pattern| word.match pattern}
+            url = Yt::URL.new word
+            url.kind == :channel && channel_id(url) == video.channel_id
+          end
+        end
       end
 
       def channel_id(url)
-        Yt::Channel.new(url: url).id
+        url.id
       rescue Yt::Errors::NoItems
       end
     end

--- a/yt-audit.gemspec
+++ b/yt-audit.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "yt", '>= 0.25.22'
+  spec.add_dependency 'yt', '>= 0.29.1'
+  spec.add_dependency 'yt-url', '>= 1.0.0.beta1'
   spec.add_dependency "yt-annotations", '~> 1.2'
 
   spec.add_development_dependency "bundler", "~> 1.11"


### PR DESCRIPTION
yt-url was extracted into a separate gem in the 95ab2a2 commit of
fullscreen/yt and the syntax was slightly changed.

Nothing changes in the code of yt-audit, only in its requirements.