### PR TITLE
Reduce YouTube API calls using .count, not .size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.5.1 - 2017-05-03
+
+* [ENHANCEMENT] Reduce API calls to YouTube using .count, not .size
+
 ## 0.5.0  - 2017-04-03
 
 **How to upgrade**

--- a/lib/yt/audit/version.rb
+++ b/lib/yt/audit/version.rb
@@ -1,5 +1,5 @@
 module Yt
   class Audit
-    VERSION = '0.5.0'
+    VERSION = '0.5.1'
   end
 end

--- a/lib/yt/playlist_audit/description.rb
+++ b/lib/yt/playlist_audit/description.rb
@@ -7,7 +7,7 @@ module Yt
       end
 
       def total_count
-        @playlists.size
+        @playlists.count
       end
 
       def valid_count

--- a/lib/yt/video_audit/base.rb
+++ b/lib/yt/video_audit/base.rb
@@ -7,7 +7,7 @@ module Yt
 
       # @return [Fixnum] number of all given videos.
       def total_count
-        @videos.size
+        @videos.count
       end
 
       # @return [Fixnum] number of videos satisfy given condition.


### PR DESCRIPTION
In principle, using `.size` is a good idea. However, `yt-core` is
not currently memoizing `size` so every call to `size` is a new call
to the YouTube API.

Since we are already using `.count` to iterate through all the items,
we are better off using `.count` everywhere so we get the memoized value.