### PR TITLE
Remove yt annotations

### DIFF
--- a/lib/yt/audit.rb
+++ b/lib/yt/audit.rb
@@ -1,18 +1,9 @@
 require 'yt/core'
-require 'yt/annotations'
 require 'yt/url'
-require 'yt/video_audit/info_card'
 require 'yt/video_audit/brand_anchoring'
-require 'yt/video_audit/subscribe_annotation'
 require 'yt/video_audit/youtube_association'
-require 'yt/video_audit/end_card'
 require 'yt/playlist_audit/description'
-require 'yt/video_audit/end_screen'
 require 'yt/video_audit/tags_length'
-require 'yt/video_audit/subscribe_end_screen'
-require 'yt/video_audit/video_end_screen'
-require 'yt/video_audit/playlist_end_screen'
-require 'yt/video_audit/website_end_screen'
 
 module Yt
   class Audit
@@ -25,18 +16,10 @@ module Yt
 
     def run
       [
-        Yt::VideoAudit::InfoCard.new(videos: @videos),
         Yt::VideoAudit::BrandAnchoring.new(videos: @videos, brand: @brand),
         Yt::VideoAudit::YoutubeAssociation.new(videos: @videos),
         Yt::PlaylistAudit::Description.new(playlists: @playlists),
-        Yt::VideoAudit::EndScreen.new(videos: @videos),
         Yt::VideoAudit::TagsLength.new(videos: @videos),
-        Yt::VideoAudit::SubscribeEndScreen.new(videos: @videos),
-        Yt::VideoAudit::VideoEndScreen.new(videos: @videos),
-        Yt::VideoAudit::PlaylistEndScreen.new(videos: @videos),
-        Yt::VideoAudit::WebsiteEndScreen.new(videos: @videos),
-        Yt::VideoAudit::EndCard.new(videos: @videos),
-        Yt::VideoAudit::SubscribeAnnotation.new(videos: @videos),
       ]
     end
   end

--- a/test/yt/audit_test.rb
+++ b/test/yt/audit_test.rb
@@ -11,65 +11,25 @@ class Yt::AuditTest < Minitest::Test
     audit = Yt::Audit.new(channel: @channel)
     result = audit.run
 
-    assert_equal 'Info Cards', result[0].title
-    assert_equal "The number of videos with an info card", result[0].description
-    assert_equal 2, result[0].valid_count
+    assert_equal 'Brand Anchoring', result[0].title
+    assert_equal "The number of videos with the brand name in the title", result[0].description
+    assert_equal 3, result[0].valid_count
     assert_equal 7, result[0].total_count
 
-    assert_equal 'Brand Anchoring', result[1].title
-    assert_equal "The number of videos with the brand name in the title", result[1].description
-    assert_equal 3, result[1].valid_count
+    assert_equal 'YouTube Association', result[1].title
+    assert_equal "The number of videos where the description has a link to its own channel", result[1].description
+    assert_equal 2, result[1].valid_count
     assert_equal 7, result[1].total_count
 
-    assert_equal 'YouTube Association', result[2].title
-    assert_equal "The number of videos where the description has a link to its own channel", result[2].description
-    assert_equal 2, result[2].valid_count
-    assert_equal 7, result[2].total_count
+    assert_equal 'Playlist Description', result[2].title
+    assert_equal "The number of playlists with a description", result[2].description
+    assert_equal 1, result[2].valid_count
+    assert_equal 4, result[2].total_count
 
-    assert_equal 'Playlist Description', result[3].title
-    assert_equal "The number of playlists with a description", result[3].description
+    assert_equal 'Length of Tags', result[3].title
+    assert_equal "The number of videos that use at least 80\% of the available tags length limit", result[3].description
     assert_equal 1, result[3].valid_count
-    assert_equal 4, result[3].total_count
-
-    assert_equal 'End Screens', result[4].title
-    assert_equal "The number of videos with at least one end screen element", result[4].description
-    assert_equal 2, result[4].valid_count
-    assert_equal 7, result[4].total_count
-
-    assert_equal 'Length of Tags', result[5].title
-    assert_equal "The number of videos that use at least 80\% of the available tags length limit", result[5].description
-    assert_equal 1, result[5].valid_count
-    assert_equal 7, result[5].total_count
-
-    assert_equal 'Subscribe End Screens', result[6].title
-    assert_equal "The number of videos with any link to subscribe in its end screens", result[6].description
-    assert_equal 1, result[6].valid_count
-    assert_equal 7, result[6].total_count
-
-    assert_equal 'Video End Screens', result[7].title
-    assert_equal "The number of videos with any link to a video in its end screens", result[7].description
-    assert_equal 2, result[7].valid_count
-    assert_equal 7, result[7].total_count
-
-    assert_equal 'Playlist End Screens', result[8].title
-    assert_equal "The number of videos with any link to a playlist in its end screens", result[8].description
-    assert_equal 1, result[8].valid_count
-    assert_equal 7, result[8].total_count
-
-    assert_equal 'Website End Screens', result[9].title
-    assert_equal "The number of videos with any external link in its end screens", result[9].description
-    assert_equal 1, result[9].valid_count
-    assert_equal 7, result[9].total_count
-
-    assert_equal 'Possible End Card Annotations', result[10].title
-    assert_equal "The number of videos with a link annotation longer than 5 seconds, not an info card, at the end of its duration", result[10].description
-    assert_equal 3, result[10].valid_count
-    assert_equal 7, result[10].total_count
-
-    assert_equal 'Subscribe Annotations', result[11].title
-    assert_equal "The number of videos with a link to subscribe in its annotations", result[11].description
-    assert_equal 3, result[11].valid_count
-    assert_equal 7, result[11].total_count
+    assert_equal 7, result[3].total_count
   end
 
   def test_channel_audit_with_videos_argument
@@ -77,20 +37,11 @@ class Yt::AuditTest < Minitest::Test
     audit = Yt::Audit.new(channel: @channel, videos: videos)
     result = audit.run
 
-    assert_equal 'Info Cards', result[0].title
+    assert_equal 'Brand Anchoring', result[0].title
     assert_equal 4, result[0].total_count
 
-    assert_equal 'Brand Anchoring', result[1].title
+    assert_equal 'YouTube Association', result[1].title
     assert_equal 4, result[1].total_count
-
-    assert_equal 'Subscribe Annotations', result[11].title
-    assert_equal 4, result[11].total_count
-
-    assert_equal 'YouTube Association', result[2].title
-    assert_equal 4, result[2].total_count
-
-    assert_equal 'Possible End Card Annotations', result[10].title
-    assert_equal 4, result[10].total_count
   end
 
   def test_channel_audit_with_playlists_argument
@@ -98,16 +49,16 @@ class Yt::AuditTest < Minitest::Test
     audit = Yt::Audit.new(channel: @channel, playlists: playlists)
     result = audit.run
 
-    assert_equal 'Playlist Description', result[3].title
-    assert_equal 2, result[3].total_count
+    assert_equal 'Playlist Description', result[2].title
+    assert_equal 2, result[2].total_count
   end
 
   def test_channel_audit_with_brand_argument
     audit = Yt::Audit.new(channel: @channel, brand: 'Test')
     result = audit.run
 
-    assert_equal 'Brand Anchoring', result[1].title
-    assert_equal 2, result[1].valid_count
-    assert_equal 7, result[1].total_count
+    assert_equal 'Brand Anchoring', result[0].title
+    assert_equal 2, result[0].valid_count
+    assert_equal 7, result[0].total_count
   end
 end

--- a/yt-audit.gemspec
+++ b/yt-audit.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'yt-core', '>= 0.1.0'
   spec.add_dependency 'yt-url', '>= 1.0.0.beta2'
-  spec.add_dependency 'yt-annotations', '~> 2.0'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'minitest', "~> 5.0"


### PR DESCRIPTION
seems like YouTube removed XML pages had annotation info, so the test will be errored if we don't remove these.